### PR TITLE
Upgrade to VS 2022 Solution and .NET Framework 4.8

### DIFF
--- a/GitTfsAuthors.sln
+++ b/GitTfsAuthors.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2037
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.37301.10 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitTfsAuthors", "GitTfsAuthors\GitTfsAuthors.csproj", "{E284BD4F-880E-4C4A-86BC-5C90F1AE6D82}"
 EndProject

--- a/GitTfsAuthors/App.config
+++ b/GitTfsAuthors/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+    </startup>
+</configuration>

--- a/GitTfsAuthors/GitTfsAuthors.csproj
+++ b/GitTfsAuthors/GitTfsAuthors.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Konpyuta.GitTfsAuthors</RootNamespace>
     <AssemblyName>GitTfsAuthors</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,13 +34,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.TeamFoundation.Client">
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.TeamFoundation.Client.dll</HintPath>
+      <HintPath>C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Microsoft.TeamFoundation.Client.dll</HintPath>
     </Reference>
     <Reference Include="NDesk.Options, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
@@ -52,6 +56,7 @@
     <Compile Include="TfsIdentityProvider.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/GitTfsAuthors/OptionsParser.cs
+++ b/GitTfsAuthors/OptionsParser.cs
@@ -46,7 +46,7 @@ namespace Konpyuta.GitTfsAuthors
         {
             _optionSet.WriteOptionDescriptions(writer);
         }
-    
+
         /// <summary>
         /// Validates the parsed arguments.
         /// </summary>

--- a/GitTfsAuthors/Properties/AssemblyInfo.cs
+++ b/GitTfsAuthors/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("GitTfsAuthors")]

--- a/GitTfsAuthors/packages.config
+++ b/GitTfsAuthors/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NDesk.Options" version="0.2.1" targetFramework="net461" />
+  <package id="NDesk.Options" version="0.2.1" targetFramework="net48" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ Cause: The current Windows session has no cached credential for the TFS host, so
 
 Fix: Open the TFS web access URL (e.g. http://tfs:8080/tfs) in a browser as the same Windows user that will run the tool, and sign in if prompted. Re-run the tool from the same session.
 
-2. The output text is not updated or is empty
+2. Output file is empty or missing domain users
 
 Symptom: The script completes but the output text is blank or some users are absent.
 
-Fix: Re-run using the attribute -k (or --keep-empty-email) to include accounts that have no email address recorded in TFS. By default these are filtered out. Confirm also that the current TFS user has read access to the Project Collection if the output is blank.
+Fix: Confirm that the current TFS user has read access to the Project Collection if the output is blank, and re-run using the attribute -k (or --keep-empty-email) to include accounts that have no email address recorded in TFS. By default entries without emails are filtered out.
 
 ## Notes
 
-For use with Team Foundation Server or Azure DevOps Server (on-premise). Not compatible with Azure DevOps Services.
+For use with Team Foundation Server or Azure DevOps Server (on-premise). Not compatible with Azure DevOps Services as the underlying identity API (IGroupSecurityService) is on-premise only.

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ Fix: Re-run using the attribute -k (or --keep-empty-email) to include accounts t
 
 ## Notes
 
-For use with Team Foundation Server or Azure DevOps Server (on-premise). Not compatible with Azure DevOps Services — the underlying IGroupSecurityService API is not exposed in the cloud product.
+For use with Team Foundation Server or Azure DevOps Server (on-premise). Not compatible with Azure DevOps Services.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ GitTfsAuthors --tfs-server-uri http://tfs:8080/tfs --authors=output.txt --sort
 
 1. EnsureAuthenticated fails with TF31002 (HTTP 404 not found error) on first run
 
-Symptom: the tool exits immediately with a TeamFoundationServiceUnavailableException / TF31002, and the inner exception is an HTTP 404. The TFS server URL is correct and reachable in a browser.
-
-Cause: the current Windows session has no cached credential for the TFS host, so WinHTTP cannot perform silent NTLM authentication. The TFS client SDK reports this as TF31002 rather than an auth error.
+Symptom: The tool exits immediately with a TeamFoundationServiceUnavailableException / TF31002, and the inner exception is an HTTP 404. The TFS server URL is correct and reachable in a browser.
 
 ```
 Example error:
@@ -48,7 +46,9 @@ Azure DevOps Server Url: http://tfs:8080/tfs/defaultcollection
 - The password has expired or is incorrect.
 ```
 
-Fix: open the TFS web access URL (e.g. http://tfs:8080/tfs) in a browser as the same Windows user that will run the tool, and sign in if prompted. Re-run the tool from the same session.
+Cause: The current Windows session has no cached credential for the TFS host, so WinHTTP cannot perform silent NTLM authentication. The TFS client SDK reports this as TF31002 rather than an auth error.
+
+Fix: Open the TFS web access URL (e.g. http://tfs:8080/tfs) in a browser as the same Windows user that will run the tool, and sign in if prompted. Re-run the tool from the same session.
 
 2. The output text is not updated or is empty
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ GitTfsAuthors --tfs-server-uri http://tfs:8080/tfs --authors=output.txt --sort
 ```
 
 ## Prerequisites
-* You'll need Visual Studio 2017, 2019, 2022 to build, because of the reference to Microsoft.TeamFoundation.Client.dll
+* You'll need Visual Studio 2022 to build, because of the reference to Microsoft.TeamFoundation.Client.dll
     
 ## See also
 * git-tfs-clone: https://github.com/git-tfs/git-tfs/blob/master/doc/commands/clone.md

--- a/README.md
+++ b/README.md
@@ -24,7 +24,38 @@ GitTfsAuthors --tfs-server-uri http://tfs:8080/tfs --authors=output.txt --sort
 ```
 
 ## Prerequisites
-* You'll need Visual Studio 2017 or 2019 to build, because of the reference to Microsoft.TeamFoundation.Client.dll
+* You'll need Visual Studio 2017, 2019, 2022 to build, because of the reference to Microsoft.TeamFoundation.Client.dll
     
 ## See also
 * git-tfs-clone: https://github.com/git-tfs/git-tfs/blob/master/doc/commands/clone.md
+
+## Debugging
+
+1. EnsureAuthenticated fails with TF31002 (HTTP 404 not found error) on first run
+
+Symptom: the tool exits immediately with a TeamFoundationServiceUnavailableException / TF31002, and the inner exception is an HTTP 404. The TFS server URL is correct and reachable in a browser.
+
+Cause: the current Windows session has no cached credential for the TFS host, so WinHTTP cannot perform silent NTLM authentication. The TFS client SDK reports this as TF31002 rather than an auth error.
+
+```
+Example error:
+
+Microsoft.TeamFoundation.TeamFoundationServiceUnavailableException: 'TF31002: Unable to connect to this Azure DevOps Server: http://tfs:8080/tfs/defaultcollection.
+Azure DevOps Server Url: http://tfs:8080/tfs/defaultcollection
+
+- The name, port number, or protocol for the Azure DevOps Server is incorrect.
+- The Azure DevOps Server is offline.
+- The password has expired or is incorrect.
+```
+
+Fix: open the TFS web access URL (e.g. http://tfs:8080/tfs) in a browser as the same Windows user that will run the tool, and sign in if prompted. Re-run the tool from the same session.
+
+2. The output text is not updated or is empty
+
+Symptom: The script completes but the output text is blank or some users are absent.
+
+Fix: Re-run using the attribute -k (or --keep-empty-email) to include accounts that have no email address recorded in TFS. By default these are filtered out. Confirm also that the current TFS user has read access to the Project Collection if the output is blank.
+
+## Notes
+
+For use with Team Foundation Server or Azure DevOps Server (on-premise). Not compatible with Azure DevOps Services — the underlying IGroupSecurityService API is not exposed in the cloud product.


### PR DESCRIPTION
Using updated Team Foundation Client for VS2022 Professional with current version of .NET Framework 4.8 SDK.